### PR TITLE
Restructured finish time logic in both reader and listener

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -108,10 +108,13 @@ class TestierWidget extends HookConsumerWidget {
         int updateCount = 0;
         for (Runner runner in ref.watch(runnerMapProvider).values) {
           if (runner.discipline.id == disc.id) {
-            for (final punch in runner.punches.values) {
+            for (final punch in runner.radioPunches.values) {
               if (!punch.isRead) {
                 updateCount++;
               }
+            }
+            if (runner.finishPunch.isPunched && !runner.finishPunch.isRead) {
+              updateCount++;
             }
           }
         }
@@ -172,8 +175,8 @@ class DisciplineTab extends HookConsumerWidget {
             .values
             .where((element) =>
                 element.discipline.id == discId &&
-                element.punches.containsKey(controlId) &&
-                !element.punches[controlId]!.isRead)
+                element.radioPunches.containsKey(controlId) &&
+                !element.radioPunches[controlId]!.isRead)
             .length;
 
         mommies.add(Text(
@@ -214,10 +217,11 @@ class RadioPunches extends HookConsumerWidget {
         .values
         .where((runner) =>
             runner.discipline.id == discId &&
-            runner.punches.containsKey(controlId))
+            runner.radioPunches.containsKey(controlId))
         .toList();
 
-    runners.sort((a, b) => a.finishedAfter.compareTo(b.finishedAfter)); // TODO
+    runners.sort((a, b) => a.radioPunches[controlId]!.punchedAfter
+        .compareTo(b.radioPunches[controlId]!.punchedAfter));
 
     return ListView(
       controller: ScrollController(),
@@ -242,11 +246,11 @@ class Finishes extends HookConsumerWidget {
         .watch(runnerMapProvider)
         .values
         .where((runner) =>
-            runner.discipline.id == discId &&
-            runner.finishedAfter.inMilliseconds.toInt() > 0)
+            runner.discipline.id == discId && runner.finishPunch.isPunched)
         .toList();
 
-    runners.sort((a, b) => a.finishedAfter.compareTo(b.finishedAfter));
+    runners.sort((a, b) =>
+        a.finishPunch.punchedAfter.compareTo(b.finishPunch.punchedAfter));
 
     return ListView(
       controller: ScrollController(),
@@ -268,7 +272,7 @@ class RunnerPunchItem extends HookConsumerWidget {
     final runner = ref.watch(_currentRunner);
     final controlId = ref.watch(_currentControlId);
 
-    void tapped() {
+    void _tapped() {
       ref
           .read(runnerMapProvider.notifier)
           .toggleControlUpdateSingle(runner.id, controlId);
@@ -276,10 +280,10 @@ class RunnerPunchItem extends HookConsumerWidget {
 
     return ListTile(
       title: Text(runner.name),
-      subtitle: Text(runner.punches[controlId]!.punchedAfter.toString()),
+      subtitle: Text(runner.radioPunches[controlId]!.punchedAfter.toString()),
       tileColor:
-          runner.punches[controlId]!.isRead ? Colors.white : Colors.green,
-      onTap: tapped,
+          runner.radioPunches[controlId]!.isRead ? Colors.white : Colors.green,
+      onTap: _tapped,
     );
   }
 }
@@ -291,66 +295,15 @@ class RunnerFinishItem extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final runner = ref.watch(_currentRunner);
 
+    void _tapped() {
+      ref.read(runnerMapProvider.notifier).toggleFinishUpdateSingle(runner.id);
+    }
+
     return ListTile(
       title: Text(runner.name),
-      subtitle: Text(runner.finishedAfter.toString()),
+      subtitle: Text(runner.finishPunch.punchedAfter.toString()),
+      tileColor: runner.finishPunch.isRead ? Colors.white : Colors.green,
+      onTap: _tapped,
     );
   }
 }
-
-// class YayWidget extends HookConsumerWidget {
-//   YayWidget({Key? key}) : super(key: key);
-
-//   @override
-//   Widget build(BuildContext context, WidgetRef ref) {
-//     final clubs = ref.watch(clubMapProvider).values.toList();
-//     final controls = ref.watch(controlMapProvider).values.toList();
-//     final disciplines = ref.watch(disciplineMapProvider).values.toList();
-//     final runners = ref.watch(runnerMapProvider).values.toList();
-
-//     List<ListTile> allTheThings() {
-//       final List<ListTile> things = [];
-//       for (Club club in clubs) {
-//         things.add(ListTile(
-//           title: Text(club.name),
-//           subtitle: Text(club.country.toString()),
-//         ));
-//       }
-
-//       for (Control control in controls) {
-//         things.add(ListTile(
-//           title: Text(control.name),
-//           subtitle: Text(control.id.toString()),
-//         ));
-//       }
-
-//       for (Discipline discipline in disciplines) {
-//         things.add(ListTile(
-//           title: Text(discipline.name),
-//           subtitle: Text(discipline.id.toString()),
-//         ));
-//       }
-
-//       for (Runner runner in runners) {
-//         things.add(ListTile(
-//           title: Text(runner.name),
-//           subtitle: Text(runner.club.name),
-//         ));
-//       }
-
-//       return things;
-//     }
-
-//     //return Text(clubs.first.name);
-
-//     return Column(
-//       children: [
-//         Expanded(
-//           child: ListView(
-//             children: allTheThings(),
-//           ),
-//         ),
-//       ],
-//     );
-//   }
-// }

--- a/lib/model/better_listener.dart
+++ b/lib/model/better_listener.dart
@@ -1,5 +1,7 @@
 // Albert 2022-07-11: "maybe I won't need this class"
 
+import 'package:attempt4/model/dataclasses/immutable/finish_status.dart';
+
 import 'dataclasses/immutable/punch_status.dart';
 import 'enums/country.dart';
 import 'enums/runner_status.dart';
@@ -25,6 +27,7 @@ class BetterListener {
   final StateNotifierProvider<RunnerMap, Map<int, Runner>> _runners;
   final WidgetRef _ref;
   final int _batchUpdateThreshold = 3; // number pulled out of my ass
+  final DateTime _placeHolderTime = DateTime(2000);
 
   // TODO divide into four classes
 
@@ -220,6 +223,18 @@ class BetterListener {
             receivedAt: DateTime.now())
     };
 
+    final finish = FinishStatus(
+        isPunched: runner.isFinished,
+        punchedAt: runner.isFinished
+            ? _determineStartTime(runner.startTime)
+                .add(_determineRunningTime(runner.runningTime))
+            : _placeHolderTime,
+        punchedAfter: runner.isFinished
+            ? _determineRunningTime(runner.runningTime)
+            : const Duration(milliseconds: 0),
+        receivedAt: DateTime.now(),
+        isRead: false);
+
     return Runner(
         id: runner.id,
         name: runner.name,
@@ -229,12 +244,9 @@ class BetterListener {
         numberBib: runner.numberBib,
         status: runner.status,
         hasNoClub: runner.hasNoClub,
-        punches: punches,
+        radioPunches: punches,
+        finishPunch: finish,
         startTime: _determineStartTime(runner.startTime),
-        finishedAfter: _determineRunningTime(runner.runningTime),
-        finishedAt: _determineStartTime(runner.startTime)
-            .add(_determineRunningTime(runner.runningTime)),
-        hasRunningTimeUpdate: runner.runningTime != 0, // TODO not the best way
         hasStatusUpdate: runner.status != RunnerStatus.Unknown,
         updatedAt: DateTime.now());
   }

--- a/lib/model/dataclasses/immutable/finish_status.dart
+++ b/lib/model/dataclasses/immutable/finish_status.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/foundation.dart' show immutable;
+
+import 'punch_status.dart';
+
+@immutable
+class FinishStatus extends PunchStatus {
+  const FinishStatus(
+      {required this.isPunched,
+      required super.punchedAt,
+      required super.punchedAfter,
+      required super.receivedAt,
+      required super.isRead});
+
+  final bool isPunched;
+
+  @override
+  FinishStatus copyWith(
+      {bool? isPunched,
+      DateTime? punchedAt,
+      Duration? punchedAfter,
+      bool? isRead}) {
+    if (punchedAt != null || punchedAfter != null) {
+      isRead = false;
+    }
+
+    return FinishStatus(
+        isPunched: isPunched ?? this.isPunched,
+        punchedAt: punchedAt ?? this.punchedAt,
+        punchedAfter: punchedAfter ?? this.punchedAfter,
+        receivedAt: (isRead != null && !isRead) ? DateTime.now() : receivedAt,
+        isRead: isRead ?? this.isRead);
+  }
+}

--- a/lib/model/dataclasses/remote/club.dart
+++ b/lib/model/dataclasses/remote/club.dart
@@ -1,20 +1,17 @@
 import 'package:attempt4/model/enums/country.dart';
 
 class RemoteClub {
+  RemoteClub({required this.id, required this.name, required this.country}) {
+    isDeletion = false;
+  }
+
+  RemoteClub.forDeletion(
+      {required this.id, this.name = "DELETE", this.country = Country.None}) {
+    isDeletion = true;
+  }
+
   final int id;
   final String name;
   final Country country;
-  final bool isDeletion;
-
-  RemoteClub(
-      {required this.id,
-      required this.name,
-      required this.country,
-      this.isDeletion = false});
-
-  RemoteClub.forDeletion(
-      {required this.id,
-      this.name = "DELETE",
-      this.country = Country.None,
-      this.isDeletion = true});
+  late final bool isDeletion;
 }

--- a/lib/model/dataclasses/remote/control.dart
+++ b/lib/model/dataclasses/remote/control.dart
@@ -1,10 +1,12 @@
 class RemoteControl {
+  RemoteControl({required this.id, required this.name}) {
+    isDeletion = false;
+  }
+  RemoteControl.forDeletion({required this.id, this.name = "DELETE"}) {
+    isDeletion = true;
+  }
+
   final int id;
   final String name;
-  final bool isDeletion;
-
-  RemoteControl(
-      {required this.id, required this.name, this.isDeletion = false});
-  RemoteControl.forDeletion(
-      {required this.id, this.name = "DELETE", this.isDeletion = true});
+  late final bool isDeletion;
 }

--- a/lib/model/dataclasses/remote/discipline.dart
+++ b/lib/model/dataclasses/remote/discipline.dart
@@ -1,20 +1,18 @@
 /// an orienteering class, but naming a class Class risks confusion
 
 class RemoteDiscipline {
+  RemoteDiscipline(
+      {required this.id, required this.name, required this.controls}) {
+    isDeletion = false;
+  }
+
+  RemoteDiscipline.forDeletion(
+      {required this.id, this.name = "DELETE", this.controls = const []}) {
+    isDeletion = true;
+  }
+
   final int id;
   final String name;
   final List<int> controls;
-  final bool isDeletion;
-
-  RemoteDiscipline(
-      {required this.id,
-      required this.name,
-      required this.controls,
-      this.isDeletion = false});
-
-  RemoteDiscipline.forDeletion(
-      {required this.id,
-      this.name = "DELETE",
-      this.controls = const [],
-      this.isDeletion = true});
+  late final bool isDeletion;
 }

--- a/lib/model/dataclasses/remote/runner.dart
+++ b/lib/model/dataclasses/remote/runner.dart
@@ -3,19 +3,6 @@ import 'package:attempt4/model/enums/country.dart';
 import '../../enums/runner_status.dart';
 
 class RemoteRunner {
-  final int id;
-  final String name;
-  final int clubId;
-  final int discId;
-  final Country country;
-  final String? numberBib;
-  final int startTime; // milliseconds past 00:00 of the event day
-  final Map<int, int> radioTimes; // <controlId, milliseconds>
-  final int runningTime; // a duration in milliseconds
-  final RunnerStatus status;
-  final bool hasNoClub;
-  final bool isDeletion;
-
   RemoteRunner(
       {required this.id,
       required this.name,
@@ -26,9 +13,11 @@ class RemoteRunner {
       required this.startTime,
       required this.radioTimes,
       required this.runningTime,
+      required this.isFinished,
       required this.status,
-      required this.hasNoClub,
-      this.isDeletion = false});
+      required this.hasNoClub}) {
+    isDeletion = false;
+  }
 
   RemoteRunner.forDeletion(
       {required this.id,
@@ -40,7 +29,23 @@ class RemoteRunner {
       this.startTime = 0,
       this.radioTimes = const {},
       this.runningTime = 0,
+      this.isFinished = false,
       this.status = RunnerStatus.Cancelled,
-      this.hasNoClub = true,
-      this.isDeletion = true});
+      this.hasNoClub = true}) {
+    isDeletion = true;
+  }
+
+  final int id;
+  final String name;
+  final int clubId;
+  final int discId;
+  final Country country;
+  final String? numberBib;
+  final int startTime; // milliseconds past 00:00 of the event day
+  final Map<int, int> radioTimes; // <controlId, milliseconds>
+  final int runningTime; // a duration in milliseconds
+  final bool isFinished;
+  final RunnerStatus status;
+  final bool hasNoClub;
+  late final bool isDeletion;
 }

--- a/lib/model/remotes/meos/reader.dart
+++ b/lib/model/remotes/meos/reader.dart
@@ -196,6 +196,7 @@ class MeOSreader {
             startTime: startTime,
             radioTimes: radioTimes,
             runningTime: runningTime,
+            isFinished: runningTime != 0,
             status: status,
             hasNoClub: hasNoClub);
       }


### PR DESCRIPTION
* MeOSreader now figures out if a runner has finished instead of delegating it to the general listener
* Reason: A runningtime of 0 is not necessarily how other databases will express that the runner hasn't finished
* Slightly changed constructors for remote dataclasses to reduce risk of mismanaged deletions
* New class FinishStatus to make finish logic more similar to punch logic
* GUI can now track and toggle isRead for finishes too